### PR TITLE
chore(ci): 新增 pr-commit-label.yml 文件

### DIFF
--- a/.github/workflows/pr-commit-label.yml
+++ b/.github/workflows/pr-commit-label.yml
@@ -1,0 +1,51 @@
+name: PR conventional labeled
+
+on:
+  pull_request:
+    branches: [master]
+    types:
+      [opened, reopened, labeled, unlabeled]
+
+jobs:
+  assign-labels:
+    runs-on: ubuntu-latest
+    name: Assign labels in pull request
+    if: github.event.pull_request.merged == false
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: mauroalderete/action-assign-labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          conventional-commits: |
+            conventional-commits:
+              - type: 'fix'
+                nouns: ['FIX', 'Fix', 'fix', 'FIXED', 'Fixed', 'fixed']
+                labels: ['bug','patch']
+              - type: 'feature'
+                nouns: ['FEATURE', 'Feature', 'feature', 'FEAT', 'Feat', 'feat']
+                labels: ['feature','minar']
+              - type: 'breaking_change'
+                nouns: ['BREAKING CHANGE', 'BREAKING', 'MAJOR']
+                labels: ['BREAKING CHANGE','major']
+              - type: 'documentation'
+                nouns: ['doc','docs','document','documentation']
+                labels: ['documentation']
+              - type: 'build'
+                nouns: ['build','rebuild']
+                labels: ['build','skip-release']
+              - type: 'chore'
+                nouns: ['chore', 'CHORE']
+                labels: ['chore']
+              - type: 'style'
+                nouns: ['stlye','STYLE']
+                labels: ['chore']                
+              - type: 'refactor'
+                nouns: ['refactor', 'REFACTOR']
+                labels: ['chore']           
+              - type: 'pref'
+                nouns: ['pref', 'PREF','performance','PERFORMANCE']
+                labels: ['chore']           
+              - type: 'test'
+                nouns: ['test', 'TEST']
+                labels: ['chore']

--- a/.github/workflows/pr-commit-label.yml
+++ b/.github/workflows/pr-commit-label.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: mauroalderete/action-assign-labels@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          maintain-labels-not-matched: true
+          apply-changes: true
           conventional-commits: |
             conventional-commits:
               - type: 'fix'
@@ -24,7 +26,7 @@ jobs:
                 labels: ['bug','patch']
               - type: 'feature'
                 nouns: ['FEATURE', 'Feature', 'feature', 'FEAT', 'Feat', 'feat']
-                labels: ['feature','minar']
+                labels: ['feature','minor']
               - type: 'breaking_change'
                 nouns: ['BREAKING CHANGE', 'BREAKING', 'MAJOR']
                 labels: ['BREAKING CHANGE','major']

--- a/.github/workflows/pr-commit-label.yml
+++ b/.github/workflows/pr-commit-label.yml
@@ -35,7 +35,7 @@ jobs:
                 labels: ['documentation']
               - type: 'build'
                 nouns: ['build','rebuild']
-                labels: ['build','skip-release']
+                labels: ['build','release/skip']
               - type: 'chore'
                 nouns: ['chore', 'CHORE']
                 labels: ['chore']


### PR DESCRIPTION
这个 ci 可以自动根据 ConvertionalCommit 自动打标签，包括版本标签

## 本次提交包含什么范围
- [ ] [fix]修复（对缺陷的修复） 
- [ ] [feat]功能（新功能、特性的开发）
- [ ] [docs]文档（仅对当前版本的文档进行增加、完善和更新）
- [ ] [pref]性能（改进性能的代码更改）
- [ ] [refactor]重构（既不修复bug也不添加特性的代码更改）
- [ ] [style]风格（不影响代码含义的更改(空白、格式化、缺少分号等)
- [ ] [test]测试（添加缺失的测试或修改现有的测试）
- [ ] [build]编译（影响构建系统或外部依赖的更改）
- [x] [ci]集成（对CI配置文件和脚本的更改）
- [ ] [others]其他，请说明：

> 参考 [https://www.conventionalcommits.org/zh-hans/v1.0.0/](https://www.conventionalcommits.org/zh-hans/v1.0.0/)

## 关联的 ISSUE 编号（一行一个）
